### PR TITLE
Option to add noise free pulses

### DIFF
--- a/configs/default_track_snowstorm.yaml
+++ b/configs/default_track_snowstorm.yaml
@@ -159,6 +159,8 @@ det_low_mem: False
 det_filter_trigger: True
 # do not run Vuvuzela.
 det_skip_noise_generation: False
+# add noise-free pulses in addition to normal simulation
+add_no_noise_pulses: False
 # convert I3MCTree to linearized version if True
 det_convert_to_linear_tree: True
 # If this is a Genie simulation, then this needs to be set to True

--- a/job_templates/py2-v3.0.1.sh
+++ b/job_templates/py2-v3.0.1.sh
@@ -19,8 +19,8 @@ eval `/cvmfs/icecube.opensciencegrid.org/py2-v3.0.1/setup.sh`
 export PYTHONUSERBASE=/data/user/mhuennefeld/DNN_reco/virtualenvs/tensorflow_cpu_py2-v3.0.1/
 echo 'Using PYTHONUSERBASE: '${PYTHONUSERBASE}
 
-export ENV_SITE_PACKGES=$(find ${PYTHONUSERBASE}/lib* -maxdepth 2 -type d -name "site-packages")
-export PYTHONPATH=$ENV_SITE_PACKGES:$PYTHONPATH
+export ENV_SITE_PACKAGES=$(find ${PYTHONUSERBASE}/lib* -maxdepth 2 -type d -name "site-packages")
+export PYTHONPATH=$ENV_SITE_PACKAGES:$PYTHONPATH
 export PATH=$PYTHONUSERBASE/bin:$PATH
 echo 'Using PYTHONPATH: '${PYTHONPATH}
 

--- a/job_templates/py3-v4.0.1__diffuse_numu.sh
+++ b/job_templates/py3-v4.0.1__diffuse_numu.sh
@@ -19,8 +19,8 @@ eval `/cvmfs/icecube.opensciencegrid.org/py3-v4.0.1/setup.sh`
 export PYTHONUSERBASE=/data/user/mhuennefeld/DNN_reco/virtualenvs/tensorflow_v1.14.0_cpu_py3-v4.0.1__diffuse_numu
 echo 'Using PYTHONUSERBASE: '${PYTHONUSERBASE}
 
-export ENV_SITE_PACKGES=$(find ${PYTHONUSERBASE}/lib* -maxdepth 2 -type d -name "site-packages")
-export PYTHONPATH=$ENV_SITE_PACKGES:$PYTHONPATH
+export ENV_SITE_PACKAGES=$(find ${PYTHONUSERBASE}/lib* -maxdepth 2 -type d -name "site-packages")
+export PYTHONPATH=$ENV_SITE_PACKAGES:$PYTHONPATH
 export PATH=$PYTHONUSERBASE/bin:$PATH
 echo 'Using PYTHONPATH: '${PYTHONPATH}
 

--- a/job_templates/py3-v4.1.0.sh
+++ b/job_templates/py3-v4.1.0.sh
@@ -24,8 +24,8 @@ eval `/cvmfs/icecube.opensciencegrid.org/py3-v4.1.0/setup.sh`
 export PYTHONUSERBASE={python_user_base}
 echo 'Using PYTHONUSERBASE: '${PYTHONUSERBASE}
 
-export ENV_SITE_PACKGES=$(find ${PYTHONUSERBASE}/lib* -maxdepth 2 -type d -name "site-packages")
-export PYTHONPATH=$ENV_SITE_PACKGES:$PYTHONPATH
+export ENV_SITE_PACKAGES=$(find ${PYTHONUSERBASE}/lib* -maxdepth 2 -type d -name "site-packages")
+export PYTHONPATH=$ENV_SITE_PACKAGES:$PYTHONPATH
 export PATH=$PYTHONUSERBASE/bin:$PATH
 echo 'Using PYTHONPATH: '${PYTHONPATH}
 

--- a/job_templates/py3-v4.2.1.sh
+++ b/job_templates/py3-v4.2.1.sh
@@ -24,8 +24,8 @@ eval `/cvmfs/icecube.opensciencegrid.org/py3-v4.2.1/setup.sh`
 export PYTHONUSERBASE={python_user_base}
 echo 'Using PYTHONUSERBASE: '${PYTHONUSERBASE}
 
-export ENV_SITE_PACKGES=$(find ${PYTHONUSERBASE}/lib* -maxdepth 2 -type d -name "site-packages")
-export PYTHONPATH=$ENV_SITE_PACKGES:$PYTHONPATH
+export ENV_SITE_PACKAGES=$(find ${PYTHONUSERBASE}/lib* -maxdepth 2 -type d -name "site-packages")
+export PYTHONPATH=$ENV_SITE_PACKAGES:$PYTHONPATH
 export PATH=$PYTHONUSERBASE/bin:$PATH
 echo 'Using PYTHONPATH: '${PYTHONPATH}
 

--- a/job_templates/py3-v4.3.0.sh
+++ b/job_templates/py3-v4.3.0.sh
@@ -24,8 +24,8 @@ eval `/cvmfs/icecube.opensciencegrid.org/py3-v4.3.0/setup.sh`
 export PYTHONUSERBASE={python_user_base}
 echo 'Using PYTHONUSERBASE: '${PYTHONUSERBASE}
 
-export ENV_SITE_PACKGES=$(find ${PYTHONUSERBASE}/lib* -maxdepth 2 -type d -name "site-packages")
-export PYTHONPATH=$ENV_SITE_PACKGES:$PYTHONPATH
+export ENV_SITE_PACKAGES=$(find ${PYTHONUSERBASE}/lib* -maxdepth 2 -type d -name "site-packages")
+export PYTHONPATH=$ENV_SITE_PACKAGES:$PYTHONPATH
 export PATH=$PYTHONUSERBASE/bin:$PATH
 echo 'Using PYTHONPATH: '${PYTHONPATH}
 

--- a/steps/resources/pulses.py
+++ b/steps/resources/pulses.py
@@ -78,14 +78,17 @@ class MoveSuperDST(icetray.I3ConditionalModule):
             frame[output_key] = frame[self.input_key]
 
             for key in frame.keys():
-                if isinstance(frame[key], dataclasses.I3RecoPulseSeriesMapMask):
-                    if frame[key].source == self.input_key:
-                        output_mask = self.output_key_pattern.format(key)
-                        frame[output_mask] = (
-                            dataclasses.I3RecoPulseSeriesMapMask(frame, output_key)
-                        )
-                    assert frame[output_mask].apply(frame) == frame[key].apply(frame)
-                    del frame[key]
+                try:
+                    if isinstance(frame[key], dataclasses.I3RecoPulseSeriesMapMask):
+                        if frame[key].source == self.input_key:
+                            output_mask = self.output_key_pattern.format(key)
+                            frame[output_mask] = (
+                                dataclasses.I3RecoPulseSeriesMapMask(frame, output_key)
+                            )
+                        assert frame[output_mask].apply(frame) == frame[key].apply(frame)
+                        del frame[key]
+                except KeyError:
+                    pass
 
             del frame[self.input_key]
         self.PushFrame(frame)

--- a/steps/resources/pulses.py
+++ b/steps/resources/pulses.py
@@ -502,6 +502,9 @@ class CompressPulses(icetray.I3ConditionalModule):
             n_removed += len(pulse_series) - len(new_pulses[omkey])
             n_total += len(pulse_series)
 
+        if n_total == 0:
+            return new_pulses
+
         if n_removed > 0:
             log_error('Removed {} pulses with time < {}ns.'.format(
                 n_removed, min_time))

--- a/steps/resources/pulses.py
+++ b/steps/resources/pulses.py
@@ -42,7 +42,7 @@ def GetPulses(tray, name,
     #     Feature extraction, pulse cleaning (seeded RT, and Time Window),
     #     PoleMuonLineit, PoleMuonLlh, Cuts module and Mue on PoleMuonLlh
     if sdstarchive:
-        tray.AddSegment(BaseProcessing, "BaseProc",
+        tray.AddSegment(BaseProcessing, name + "BaseProc",
                         pulses=filter_globals.CleanedMuonPulses,
                         decode=decode,
                         simulation=False,
@@ -51,7 +51,7 @@ def GetPulses(tray, name,
                         needs_trimmer=False, seededRTConfig=seededRTConfig
                         )
     else:
-        tray.AddSegment(BaseProcessing, "BaseProc",
+        tray.AddSegment(BaseProcessing, name + "BaseProc",
                         pulses=filter_globals.CleanedMuonPulses,
                         decode=decode,
                         simulation=simulation,

--- a/steps/resources/pulses.py
+++ b/steps/resources/pulses.py
@@ -78,17 +78,14 @@ class MoveSuperDST(icetray.I3ConditionalModule):
             frame[output_key] = frame[self.input_key]
 
             for key in frame.keys():
-                try:
-                    if isinstance(frame[key], dataclasses.I3RecoPulseSeriesMapMask):
-                        if frame[key].source == self.input_key:
-                            output_mask = self.output_key_pattern.format(key)
-                            frame[output_mask] = (
-                                dataclasses.I3RecoPulseSeriesMapMask(frame, output_key)
-                            )
-                        assert frame[output_mask].apply(frame) == frame[key].apply(frame)
-                        del frame[key]
-                except KeyError:
-                    pass
+                if frame.type_name(key) == "I3RecoPulseSeriesMapMas":
+                    if frame[key].source == self.input_key:
+                        output_mask = self.output_key_pattern.format(key)
+                        frame[output_mask] = (
+                            dataclasses.I3RecoPulseSeriesMapMask(frame, output_key)
+                        )
+                    assert frame[output_mask].apply(frame) == frame[key].apply(frame)
+                    del frame[key]
 
             del frame[self.input_key]
         self.PushFrame(frame)

--- a/steps/step_0_track_simulation.py
+++ b/steps/step_0_track_simulation.py
@@ -1,6 +1,11 @@
 #!/bin/sh /cvmfs/icecube.opensciencegrid.org/py3-v4.3.0/icetray-start
 #METAPROJECT icetray/v1.10.0
 from __future__ import division
+import os
+import sys
+if "ENV_SITE_PACKAGES" in os.environ:
+    sys.path.insert(1, os.environ["ENV_SITE_PACKAGES"])
+
 import time
 import click
 import yaml

--- a/steps/step_1_snowstorm_propagation.py
+++ b/steps/step_1_snowstorm_propagation.py
@@ -24,9 +24,11 @@ Adopted from:
 # OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 # CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 """
-
 import os
 import sys
+if "ENV_SITE_PACKAGES" in os.environ:
+    sys.path.insert(1, os.environ["ENV_SITE_PACKAGES"])
+
 import click
 import yaml
 import numpy as np

--- a/steps/step_2_pass2_detector_simulation.py
+++ b/steps/step_2_pass2_detector_simulation.py
@@ -83,7 +83,10 @@ def main(cfg, run_number, scratch):
         )
         tray.Add(
             "Rename", "RenameNoNoisePulses",
-            Keys=["MCPulses", "MCPulses_WithoutNoise"],
+            Keys=[
+                "I3MCPulseSeriesMap", "I3MCPulseSeriesMap_WithoutNoise",
+                "I3MCPulseSeriesMapParticleIDMap", "I3MCPulseSeriesMapParticleIDMap_WithoutNoise",
+            ],
         )
 
     tray.AddSegment(segments.DetectorSim, "Detector5Sim",

--- a/steps/step_2_pass2_detector_simulation.py
+++ b/steps/step_2_pass2_detector_simulation.py
@@ -61,36 +61,6 @@ def main(cfg, run_number, scratch):
         cfg['det_keep_propagated_mc_tree'] = True
         cfg['det_keep_mc_pulses'] = True
 
-    if "add_no_noise_pulses" in cfg and cfg["add_no_noise_pulses"]:
-        if cfg["det_skip_noise_generation"]:
-            raise ValueError(
-                "Do not use add_no_noise_pulses with "
-                "det_skip_noise_generation"
-            )
-
-        tray.AddSegment(segments.DetectorSim, "Detector5Sim",
-            RandomService='I3RandomService',
-            RunID=run_id,
-            GCDFile=cfg['gcd_pass2'],
-            KeepMCHits=cfg['det_keep_mc_hits'],
-            KeepPropagatedMCTree=cfg['det_keep_propagated_mc_tree'],
-            KeepMCPulses=cfg['det_keep_mc_pulses'],
-            SkipNoiseGenerator=True,
-            LowMem=cfg['det_low_mem'],
-            InputPESeriesMapName=MCPE_SERIES_MAP,
-            BeaconLaunches=cfg['det_add_beacon_launches'],
-            FilterTrigger=cfg['det_filter_trigger'],
-        )
-        tray.Add(
-            "Rename", "RenameNoNoisePulses",
-            Keys=[
-                "I3MCPulseSeriesMap", "I3MCPulseSeriesMap_WithoutNoise",
-                "I3MCPulseSeriesMapParticleIDMap", "I3MCPulseSeriesMapParticleIDMap_WithoutNoise",
-                "IceTopRawData", "IceTopRawData_WithoutNoise",
-                "InIceRawData", "InIceRawData_WithoutNoise",
-            ],
-        )
-
     tray.AddSegment(segments.DetectorSim, "Detector5Sim",
         RandomService='I3RandomService',
         RunID=run_id,

--- a/steps/step_2_pass2_detector_simulation.py
+++ b/steps/step_2_pass2_detector_simulation.py
@@ -61,6 +61,31 @@ def main(cfg, run_number, scratch):
         cfg['det_keep_propagated_mc_tree'] = True
         cfg['det_keep_mc_pulses'] = True
 
+    if "add_no_noise_pulses" in cfg and cfg["add_no_noise_pulses"]:
+        if cfg["det_skip_noise_generation"]:
+            raise ValueError(
+                "Do not use add_no_noise_pulses with "
+                "det_skip_noise_generation"
+            )
+
+        tray.AddSegment(segments.DetectorSim, "Detector5Sim",
+            RandomService='I3RandomService',
+            RunID=run_id,
+            GCDFile=cfg['gcd_pass2'],
+            KeepMCHits=cfg['det_keep_mc_hits'],
+            KeepPropagatedMCTree=cfg['det_keep_propagated_mc_tree'],
+            KeepMCPulses=cfg['det_keep_mc_pulses'],
+            SkipNoiseGenerator=True,
+            LowMem=cfg['det_low_mem'],
+            InputPESeriesMapName=MCPE_SERIES_MAP,
+            BeaconLaunches=cfg['det_add_beacon_launches'],
+            FilterTrigger=cfg['det_filter_trigger'],
+        )
+        tray.Add(
+            "Rename", "RenameNoNoisePulses",
+            Keys=["MCPulses", "MCPulses_WithoutNoise"],
+        )
+
     tray.AddSegment(segments.DetectorSim, "Detector5Sim",
         RandomService='I3RandomService',
         RunID=run_id,

--- a/steps/step_2_pass2_detector_simulation.py
+++ b/steps/step_2_pass2_detector_simulation.py
@@ -86,6 +86,8 @@ def main(cfg, run_number, scratch):
             Keys=[
                 "I3MCPulseSeriesMap", "I3MCPulseSeriesMap_WithoutNoise",
                 "I3MCPulseSeriesMapParticleIDMap", "I3MCPulseSeriesMapParticleIDMap_WithoutNoise",
+                "IceTopRawData", "IceTopRawData_WithoutNoise",
+                "InIceRawData", "InIceRawData_WithoutNoise",
             ],
         )
 

--- a/steps/step_2_snowstorm_detector_simulation.py
+++ b/steps/step_2_snowstorm_detector_simulation.py
@@ -131,7 +131,7 @@ def main(cfg, run_number, scratch):
             "Rename", "RenameNoNoisePulses",
             Keys=[
                 "I3MCPulseSeriesMap", "I3MCPulseSeriesMapWithoutNoise",
-                "I3MCPulseSeriesMapParticleIDMap", "I3MCPulseSeriesMapParticleIDMapWithoutNoise",
+                "I3MCPulseSeriesMapParticleIDMap", "I3MCPulseSeriesMapWithoutNoiseParticleIDMap",
                 "IceTopRawData", "IceTopRawDataWithoutNoise",
                 "InIceRawData", "InIceRawDataWithoutNoise",
                 "BeaconLaunches", "BeaconLaunchesWithoutNoise",

--- a/steps/step_2_snowstorm_detector_simulation.py
+++ b/steps/step_2_snowstorm_detector_simulation.py
@@ -114,7 +114,7 @@ def main(cfg, run_number, scratch):
                 "det_skip_noise_generation"
             )
 
-        tray.AddSegment(segments.DetectorSim, "Detector5Sim_WithoutNoise
+        tray.AddSegment(segments.DetectorSim, "DetectorSim_WithoutNoise",
             RandomService='I3RandomService',
             RunID=run_id,
             GCDFile=cfg['gcd_pass2'],

--- a/steps/step_2_snowstorm_detector_simulation.py
+++ b/steps/step_2_snowstorm_detector_simulation.py
@@ -3,6 +3,9 @@
 #--METAPROJECT /data/user/mhuennefeld/software/icecube/py3-v4.1.0/combo_V01-00-00/build
 #--METAPROJECT combo/V01-00-00 # <-- Causes segfaults, therefore use RC0
 import os
+import sys
+if "ENV_SITE_PACKAGES" in os.environ:
+    sys.path.insert(1, os.environ["ENV_SITE_PACKAGES"])
 
 import click
 import yaml

--- a/steps/step_2_snowstorm_detector_simulation.py
+++ b/steps/step_2_snowstorm_detector_simulation.py
@@ -114,7 +114,7 @@ def main(cfg, run_number, scratch):
                 "det_skip_noise_generation"
             )
 
-        tray.AddSegment(segments.DetectorSim, "DetectorSim_WithoutNoise",
+        tray.AddSegment(segments.DetectorSim, "DetectorSimWithoutNoise",
             RandomService='I3RandomService',
             RunID=run_id,
             GCDFile=cfg['gcd_pass2'],
@@ -130,10 +130,15 @@ def main(cfg, run_number, scratch):
         tray.Add(
             "Rename", "RenameNoNoisePulses",
             Keys=[
-                "I3MCPulseSeriesMap", "I3MCPulseSeriesMap_WithoutNoise",
-                "I3MCPulseSeriesMapParticleIDMap", "I3MCPulseSeriesMapParticleIDMap_WithoutNoise",
-                "IceTopRawData", "IceTopRawData_WithoutNoise",
-                "InIceRawData", "InIceRawData_WithoutNoise",
+                "I3MCPulseSeriesMap", "I3MCPulseSeriesMapWithoutNoise",
+                "I3MCPulseSeriesMapParticleIDMap", "I3MCPulseSeriesMapParticleIDMapWithoutNoise",
+                "IceTopRawData", "IceTopRawDataWithoutNoise",
+                "InIceRawData", "InIceRawDataWithoutNoise",
+                "BeaconLaunches", "BeaconLaunchesWithoutNoise",
+                "I3EventHeader", "I3EventHeaderWithoutNoise",
+                "I3TriggerHierarchy", "I3TriggerHierarchyWithoutNoise",
+                "I3Triggers", "I3TriggersWithoutNoise",
+                "TimeShift", "TimeShiftWithoutNoise",
             ],
         )
 

--- a/steps/step_2_snowstorm_detector_simulation.py
+++ b/steps/step_2_snowstorm_detector_simulation.py
@@ -114,7 +114,7 @@ def main(cfg, run_number, scratch):
                 "det_skip_noise_generation"
             )
 
-        tray.AddSegment(segments.DetectorSim, "Detector5Sim",
+        tray.AddSegment(segments.DetectorSim, "Detector5Sim_WithoutNoise
             RandomService='I3RandomService',
             RunID=run_id,
             GCDFile=cfg['gcd_pass2'],

--- a/steps/step_2_snowstorm_detector_simulation.py
+++ b/steps/step_2_snowstorm_detector_simulation.py
@@ -107,6 +107,36 @@ def main(cfg, run_number, scratch):
         cfg['det_keep_propagated_mc_tree'] = True
         cfg['det_keep_mc_pulses'] = True
 
+    if "add_no_noise_pulses" in cfg and cfg["add_no_noise_pulses"]:
+        if cfg["det_skip_noise_generation"]:
+            raise ValueError(
+                "Do not use add_no_noise_pulses with "
+                "det_skip_noise_generation"
+            )
+
+        tray.AddSegment(segments.DetectorSim, "Detector5Sim",
+            RandomService='I3RandomService',
+            RunID=run_id,
+            GCDFile=cfg['gcd_pass2'],
+            KeepMCHits=cfg['det_keep_mc_hits'],
+            KeepPropagatedMCTree=cfg['det_keep_propagated_mc_tree'],
+            KeepMCPulses=cfg['det_keep_mc_pulses'],
+            SkipNoiseGenerator=True,
+            LowMem=cfg['det_low_mem'],
+            InputPESeriesMapName=MCPE_SERIES_MAP,
+            BeaconLaunches=cfg['det_add_beacon_launches'],
+            FilterTrigger=cfg['det_filter_trigger'],
+        )
+        tray.Add(
+            "Rename", "RenameNoNoisePulses",
+            Keys=[
+                "I3MCPulseSeriesMap", "I3MCPulseSeriesMap_WithoutNoise",
+                "I3MCPulseSeriesMapParticleIDMap", "I3MCPulseSeriesMapParticleIDMap_WithoutNoise",
+                "IceTopRawData", "IceTopRawData_WithoutNoise",
+                "InIceRawData", "InIceRawData_WithoutNoise",
+            ],
+        )
+
     tray.AddSegment(segments.DetectorSim, "DetectorSim",
                     RandomService='I3RandomService',
                     RunID=run_id,

--- a/steps/step_3_pass2_get_all_pulses.py
+++ b/steps/step_3_pass2_get_all_pulses.py
@@ -277,7 +277,7 @@ def main(cfg, run_number, scratch):
         'oversampling',
         'AggregatedPulses',
         'InIceDSTPulses',
-        'InIceDSTPulsesWithowtNoise',
+        'InIceDSTPulsesWithoutNoise',
         'InIceDSTPulsesTimeRange',
         'CalibrationErrata',
         'SaturationWindows',

--- a/steps/step_3_pass2_get_all_pulses.py
+++ b/steps/step_3_pass2_get_all_pulses.py
@@ -1,5 +1,10 @@
 #!/bin/sh /cvmfs/icecube.opensciencegrid.org/py3-v4.3.0/icetray-start
 #METAPROJECT icetray/v1.10.0
+import os
+import sys
+if "ENV_SITE_PACKAGES" in os.environ:
+    sys.path.insert(1, os.environ["ENV_SITE_PACKAGES"])
+
 import time
 import click
 import yaml

--- a/steps/step_3_pass2_get_all_pulses.py
+++ b/steps/step_3_pass2_get_all_pulses.py
@@ -63,6 +63,34 @@ def main(cfg, run_number, scratch):
             GetPulses, "GetPulses", decode=False, simulation=True,
         )
 
+        if "add_no_noise_pulses" in cfg and cfg["add_no_noise_pulses"]:
+
+            # save the original MC and reco pulses, rename MCPulses to utilize
+            tray.Add(
+                "Rename", "RenameToRunWithoutNoise",
+                Keys=[
+                    "MCPulses", "temp_MCPulses",
+                    "InIceDSTPulses", "temp_InIceDSTPulses",
+                    "MCPulses_WithoutNoise", "MCPulses",
+                ],
+            )
+
+            # run reco pulses without noise
+            tray.AddSegment(
+                GetPulses, "GetPulses", decode=False, simulation=True,
+            )
+
+            # rename the created reco pulses, and revert previous ones
+            tray.Add(
+                "Rename", "RenameToRevert",
+                Keys=[
+                    "InIceDSTPulses", "InIceDSTPulses_WithoutNoise",
+                    "MCPulses", "MCPulses_WithoutNoise",
+                    "temp_MCPulses", "MCPulses",
+                    "temp_InIceDSTPulses", "InIceDSTPulses",
+                ],
+            )
+
     # get mc pulses
     output_keys = []
     if cfg['get_mc_pulses']:

--- a/steps/step_3_pass2_get_all_pulses.py
+++ b/steps/step_3_pass2_get_all_pulses.py
@@ -77,7 +77,8 @@ def main(cfg, run_number, scratch):
 
             # run reco pulses without noise
             tray.AddSegment(
-                GetPulses, "GetPulses", decode=False, simulation=True,
+                GetPulses, "GetPulses_WithoutNoise",
+                decode=False, simulation=True,
             )
 
             # rename the created reco pulses, and revert previous ones

--- a/steps/step_3_pass2_get_all_pulses.py
+++ b/steps/step_3_pass2_get_all_pulses.py
@@ -60,9 +60,6 @@ def main(cfg, run_number, scratch):
 
     # get reco pulses
     if cfg['get_reco_pulses']:
-        tray.AddSegment(
-            GetPulses, "GetPulses", decode=False, simulation=True,
-        )
 
         if "add_no_noise_pulses" in cfg and cfg["add_no_noise_pulses"]:
 
@@ -104,6 +101,8 @@ def main(cfg, run_number, scratch):
                 Keys=[
                     # rename created Pulses
                     "MCPulses", "MCPulsesWithoutNoise",
+                    "BadDomsList", "BadDomsListWithoutNoise",
+                    "BadDomsListSLC", "BadDomsListSLCWithoutNoise",
                     # move without noise keys back
                     "I3MCPulseSeriesMap", "I3MCPulseSeriesMapWithoutNoise",
                     "I3MCPulseSeriesMapParticleIDMap", "I3MCPulseSeriesMapParticleIDMapWithoutNoise",
@@ -118,6 +117,50 @@ def main(cfg, run_number, scratch):
                     "temp_BeaconLaunches", "BeaconLaunches",
                 ],
             )
+
+            # delete created keys that we don't need anymore
+            tray.Add(
+                "Delete", "DeleteNoNoisePulses",
+                Keys=[
+                    "CalibratedIceTopATWD_HLC",
+                    "CalibratedIceTopATWD_SLC",
+                    "CalibratedIceTopFADC_HLC",
+                    "CalibratedWaveformRange",
+                    "CalibratedWaveforms",
+                    "CleanIceTopRawData",
+                    "CleanInIceRawData",
+                    "ClusterCleaningExcludedTanks",
+                    "DSTTriggers",
+                    "GetPulsesBaseProc_SimTrimmer_HighCharge",
+                    "GetPulsesBaseProc_SimTrimmer_I3SuperDST_CalibratedWaveforms_Borked",
+                    "GetPulsesBaseProc_SimTrimmer_I3SuperDST_CalibratedWaveforms_Chi",
+                    "HLCTankPulses",
+                    "I3SuperDST",
+                    "IceTopCalibratedWaveformRange",
+                    "IceTopCalibratedWaveforms",
+                    "IceTopDSTPulses",
+                    "IceTopHLCPulseInfo",
+                    "IceTopHLCVEMPulses",
+                    "IceTopPulses",
+                    "IceTopPulses_HLC",
+                    "IceTopPulses_SLC",
+                    "IceTopRawData",
+                    "IceTopSLCVEMPulses",
+                    "InIceDSTPulses",
+                    "QTriggerHierarchy",
+                    "RawDSTPulses",
+                    "SLCTankPulses",
+                    "SimTrimmer",
+                    "TankPulseMergerExcludedTanks",
+                    "TankPulseMergerExcludedTanksSLC",
+                    "UncleanedInIcePulses",
+                    "UncleanedInIcePulsesTimeRange",
+                ],
+            )
+
+        tray.AddSegment(
+            GetPulses, "GetPulses", decode=False, simulation=True,
+        )
 
     # get mc pulses
     output_keys = []

--- a/steps/step_3_pass2_get_all_pulses.py
+++ b/steps/step_3_pass2_get_all_pulses.py
@@ -1,7 +1,7 @@
 #!/bin/sh /cvmfs/icecube.opensciencegrid.org/py3-v4.3.0/icetray-start
 #METAPROJECT /data/user/mhuennefeld/software/icecube/py3-v4.3.0/v1.12.0__propagate_names/build
 #-METAPROJECT icetray/v1.10.0
-#- revert to official release once "OptionToAddNoiseFreePulses" is merged
+#- revert to official release once "PropagateNames" is merged
 import os
 import sys
 if "ENV_SITE_PACKAGES" in os.environ:

--- a/steps/step_3_pass2_get_all_pulses.py
+++ b/steps/step_3_pass2_get_all_pulses.py
@@ -73,12 +73,17 @@ def main(cfg, run_number, scratch):
                     "IceTopRawData", "temp_IceTopRawData",
                     "InIceRawData", "temp_InIceRawData",
                     "BeaconLaunches", "temp_BeaconLaunches",
+                    "I3TriggerHierarchy", "temp_I3TriggerHierarchy",
+                    "I3Triggers", "temp_I3Triggers",
+
                     # Move WithoutNoise to the original key
                     "I3MCPulseSeriesMapWithoutNoise", "I3MCPulseSeriesMap",
-                    "I3MCPulseSeriesMapParticleIDMapWithoutNoise", "I3MCPulseSeriesMapParticleIDMap",
+                    "I3MCPulseSeriesMapWithoutNoiseParticleIDMap", "I3MCPulseSeriesMapParticleIDMap",
                     "IceTopRawDataWithoutNoise", "IceTopRawData",
                     "InIceRawDataWithoutNoise", "InIceRawData",
                     "BeaconLaunchesWithoutNoise", "BeaconLaunches",
+                    "I3TriggerHierarchyWithoutNoise", "I3TriggerHierarchy",
+                    "I3TriggersWithoutNoise", "I3Triggers",
                 ],
             )
 
@@ -105,16 +110,20 @@ def main(cfg, run_number, scratch):
                     "BadDomsListSLC", "BadDomsListSLCWithoutNoise",
                     # move without noise keys back
                     "I3MCPulseSeriesMap", "I3MCPulseSeriesMapWithoutNoise",
-                    "I3MCPulseSeriesMapParticleIDMap", "I3MCPulseSeriesMapParticleIDMapWithoutNoise",
+                    "I3MCPulseSeriesMapParticleIDMap", "I3MCPulseSeriesMapWithoutNoiseParticleIDMap",
                     "IceTopRawData", "IceTopRawDataWithoutNoise",
                     "InIceRawData", "InIceRawDataWithoutNoise",
                     "BeaconLaunches", "BeaconLaunchesWithoutNoise",
+                    "I3TriggerHierarchy", "I3TriggerHierarchyWithoutNoise",
+                    "I3Triggers", "I3TriggersWithoutNoise",
                     # revert original keys
                     "temp_I3MCPulseSeriesMap", "I3MCPulseSeriesMap",
                     "temp_I3MCPulseSeriesMapParticleIDMap", "I3MCPulseSeriesMapParticleIDMap",
                     "temp_IceTopRawData", "IceTopRawData",
                     "temp_InIceRawData", "InIceRawData",
                     "temp_BeaconLaunches", "BeaconLaunches",
+                    "temp_I3TriggerHierarchy", "I3TriggerHierarchy",
+                    "temp_I3Triggers", "I3Triggers",
                 ],
             )
 
@@ -258,10 +267,12 @@ def main(cfg, run_number, scratch):
         'MMCTrackList',
         'I3EventHeader',
         'I3SuperDST',
+        'I3SuperDSTWithoutNoise',
         'RNGState',
         'oversampling',
         'AggregatedPulses',
         'InIceDSTPulses',
+        'InIceDSTPulsesWithowtNoise',
         'InIceDSTPulsesTimeRange',
         'CalibrationErrata',
         'SaturationWindows',

--- a/steps/step_3_pass2_get_all_pulses.py
+++ b/steps/step_3_pass2_get_all_pulses.py
@@ -1,5 +1,7 @@
 #!/bin/sh /cvmfs/icecube.opensciencegrid.org/py3-v4.3.0/icetray-start
-#METAPROJECT icetray/v1.10.0
+#METAPROJECT /data/user/mhuennefeld/software/icecube/py3-v4.3.0/v1.12.0__propagate_names/build
+#-METAPROJECT icetray/v1.10.0
+#- revert to official release once "OptionToAddNoiseFreePulses" is merged
 import os
 import sys
 if "ENV_SITE_PACKAGES" in os.environ:
@@ -111,6 +113,8 @@ def main(cfg, run_number, scratch):
                 Keys=[
                     # rename created Pulses
                     "MCPulses", "MCPulsesWithoutNoise",
+                    "InIceDSTPulses", "InIceDSTPulsesWithoutNoise",
+                    "IceTopDSTPulses", "IceTopDSTPulsesWithoutNoise",
                     "BadDomsList", "BadDomsListWithoutNoise",
                     "BadDomsListSLC", "BadDomsListSLCWithoutNoise",
                     # move without noise keys back
@@ -132,45 +136,73 @@ def main(cfg, run_number, scratch):
                 ],
             )
 
-            # delete created keys that we don't need anymore
-            tray.Add(
-                "Delete", "DeleteNoNoisePulses",
-                Keys=[
-                    "CalibratedIceTopATWD_HLC",
-                    "CalibratedIceTopATWD_SLC",
-                    "CalibratedIceTopFADC_HLC",
-                    "CalibratedWaveformRange",
-                    "CalibratedWaveforms",
-                    "CleanIceTopRawData",
-                    "CleanInIceRawData",
-                    "ClusterCleaningExcludedTanks",
-                    "DSTTriggers",
-                    "GetPulsesBaseProc_SimTrimmer_HighCharge",
-                    "GetPulsesBaseProc_SimTrimmer_I3SuperDST_CalibratedWaveforms_Borked",
-                    "GetPulsesBaseProc_SimTrimmer_I3SuperDST_CalibratedWaveforms_Chi",
-                    "HLCTankPulses",
-                    "I3SuperDST",
-                    "IceTopCalibratedWaveformRange",
-                    "IceTopCalibratedWaveforms",
-                    "IceTopDSTPulses",
-                    "IceTopHLCPulseInfo",
-                    "IceTopHLCVEMPulses",
-                    "IceTopPulses",
-                    "IceTopPulses_HLC",
-                    "IceTopPulses_SLC",
-                    "IceTopRawData",
-                    "IceTopSLCVEMPulses",
-                    "InIceDSTPulses",
-                    "QTriggerHierarchy",
-                    "RawDSTPulses",
-                    "SLCTankPulses",
-                    "SimTrimmer",
-                    "TankPulseMergerExcludedTanks",
-                    "TankPulseMergerExcludedTanksSLC",
-                    "UncleanedInIcePulses",
-                    "UncleanedInIcePulsesTimeRange",
-                ],
+            # remove physics frames
+            tray.AddModule(
+                "KeepFromSubstream", "DeleteSubstreamNoNoise",
+                StreamName=filter_globals.InIceSplitter,
+                KeepKeys=['do_not_keep_anything'],
             )
+            tray.AddModule(
+                "KeepFromSubstream", "DeleteSubstreamNoNoiseNullSplit",
+                StreamName=filter_globals.NullSplitter,
+                KeepKeys=['do_not_keep_anything'],
+            )
+
+            # remove unneeded keys
+            tray.AddModule(
+                "Delete", "DeleteKeysNoNoise",
+                Keys = [
+                    'CalibratedIceTopATWD_HLC',
+                    'CalibratedIceTopATWD_SLC',
+                    'CalibratedIceTopFADC_HLC',
+                    'CalibratedWaveformRange',
+                    'CalibratedWaveforms',
+                    'CleanIceTopRawData',
+                    'CleanInIceRawData',
+                    'ClusterCleaningExcludedTanks',
+                    'DMIceSMTTriggered',
+                    'DSTTriggers',
+                    'DeepCoreSMTTriggered',
+                    'FaintParticleTriggered',
+                    'FixedRateTriggered',
+                    'GetPulsesBaseProc_SimTrimmer_HighCharge',
+                    'GetPulsesBaseProc_SimTrimmer_I3SuperDST_CalibratedWaveforms_Borked',
+                    'GetPulsesBaseProc_SimTrimmer_I3SuperDST_CalibratedWaveforms_Chi',
+                    'GetPulsesWithoutNoiseBaseProc_SimTrimmer_HighCharge',
+                    'GetPulsesWithoutNoiseBaseProc_SimTrimmer_I3SuperDST_CalibratedWaveforms_Borked',
+                    'GetPulsesWithoutNoiseBaseProc_SimTrimmer_I3SuperDST_CalibratedWaveforms_Chi',
+                    'HLCTankPulses',
+                    'I3FlasherSubrunMap',
+                    'IceActSMTTriggered',
+                    'IceTopCalibratedWaveformRange',
+                    'IceTopCalibratedWaveforms',
+                    'IceTopHLCPulseInfo',
+                    'IceTopHLCVEMPulses',
+                    'IceTopPulses',
+                    'IceTopPulses_HLC',
+                    'IceTopPulses_SLC',
+                    'IceTopSLCVEMPulses',
+                    'IceTopSMTTriggered',
+                    'IceTopVolumeTriggered',
+                    'InIceSMTTriggered',
+                    'InIceStringTriggered',
+                    'PhysMinBiasTriggered',
+                    'QTriggerHierarchy',
+                    'RawDSTPulses',
+                    'SLCTankPulses',
+                    'SPEAbove',
+                    'SPEScalingFactors',
+                    'ScintMinBiasTriggered',
+                    'SimTrimmer',
+                    'SlowParticleTriggered',
+                    'TankPulseMergerExcludedTanks',
+                    'TankPulseMergerExcludedTanksSLC',
+                    'UncleanedInIcePulses',
+                    'UncleanedInIcePulsesTimeRange',
+                    'VolumeTriggerFlag',
+        ],
+            )
+
 
         tray.AddSegment(
             GetPulses, "GetPulses", decode=False, simulation=True,
@@ -265,6 +297,7 @@ def main(cfg, run_number, scratch):
 
     keys_to_keep = [
         'TimeShift',
+        'TimeShiftWithoutNoise',
         'I3MCTree_preMuonProp',
         'I3MCTree',
         'I3MCWeightDict',
@@ -286,6 +319,7 @@ def main(cfg, run_number, scratch):
         'SplitUncleanedInIcePulsesTimeRange',
         'SplitUncleanedInIceDSTPulsesTimeRange',
         'I3TriggerHierarchy',
+        'I3TriggerHierarchyWithoutNoise',
         'GCFilter_GCFilterMJD',
         ]
     keys_to_keep += filter_globals.inice_split_keeps

--- a/steps/step_3_pass2_get_all_pulses.py
+++ b/steps/step_3_pass2_get_all_pulses.py
@@ -95,7 +95,7 @@ def main(cfg, run_number, scratch):
             tray.AddModule(
                 MoveSuperDST, "MoveSuperDST",
                 InputKey="I3SuperDST",
-                OutputKeOutputKeyPatternPrefix="{}WithoutNoise",
+                OutputKeyPattern="{}WithoutNoise",
             )
 
             # rename the created reco pulses, and revert previous ones


### PR DESCRIPTION
Adds option to add noise-free pulses in the same i3-file. Also adds `ENV_SITE_PACKAGES` option to prepend to sys.path from within python. This is required in newer icetray releases to ensure packages are read from specified virtual env instead of cvmfs